### PR TITLE
fix: iOS Safari layout - prevent white gaps and unwanted scrolling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,28 @@
 @tailwind components;
 @tailwind utilities;
 
+/* iOS Safari viewport fixes */
+html {
+  height: 100%;
+  overflow: hidden;
+  position: fixed;
+  width: 100%;
+}
+
+body {
+  height: 100%;
+  overflow: hidden;
+  position: fixed;
+  width: 100%;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* Prevent pull-to-refresh and bounce scrolling on iOS */
+html, body {
+  overscroll-behavior: none;
+  -webkit-overflow-scrolling: touch;
+}
+
 /* :root { */
 /*   --white: #fff;         /* bg-white or text-white */
 /*   --background: #282C34; /* bg-gray-800 */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,13 @@ const ibmPlexMono = IBM_Plex_Mono({
 export const metadata: Metadata = {
   title: "Daniel Ryan",
   description: "My personal website",
+  viewport: {
+    width: "device-width",
+    initialScale: 1,
+    maximumScale: 1,
+    userScalable: false,
+    viewportFit: "cover",
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
- Add proper viewport meta tag with viewport-fit=cover for iOS Safari
- Set html/body to fixed position with 100% height/width
- Prevent overscroll behavior and bounce scrolling
- Add -webkit-overflow-scrolling for smooth scrolling

Fixes white gaps at top/bottom and unwanted page scrolling on iOS 26 Safari.

🤖 Generated with [Claude Code](https://claude.com/claude-code)