### PR TITLE
Add Vercel configuration for redirects and security headers

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,26 @@
+{
+  "redirects": [
+    {
+      "source": "/:path*",
+      "has": [
+        {
+          "type": "host",
+          "value": "www.danielryan.xyz"
+        }
+      ],
+      "destination": "https://danielryan.xyz/:path*",
+      "permanent": true
+    }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=63072000; includeSubDomains; preload"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
This PR adds a `vercel.json` configuration file to set up domain redirects and security headers for the Vercel deployment.

## Key Changes
- **WWW redirect**: Configured a permanent redirect from `www.danielryan.xyz` to `danielryan.xyz` to enforce the non-www domain
- **Security headers**: Added Strict-Transport-Security (HSTS) header with a 2-year max-age to enforce HTTPS across all requests and subdomains, with preload enabled for inclusion in browser HSTS preload lists

## Implementation Details
- The redirect uses a host-based condition to match only requests to the www subdomain, ensuring all traffic is consolidated to the primary domain
- HSTS header is applied globally to all routes with `max-age=63072000` (2 years), `includeSubDomains` to protect subdomains, and `preload` flag for HSTS preload list eligibility
- Both configurations follow Vercel's standard configuration format and best practices for production deployments

https://claude.ai/code/session_01JQ84LNbEy2UYTWHSvHZ4zi