### PR TITLE
Fix mobile nav wrapping and uses page header colors

### DIFF
--- a/src/app/uses/page.tsx
+++ b/src/app/uses/page.tsx
@@ -9,7 +9,7 @@ function Section({
 }) {
   return (
     <div>
-      <h2 className="text-onedark-yellow font-bold mb-3">{title}</h2>
+      <h2 className="text-onedark-purple font-bold mb-3">{title}</h2>
       <ul className="space-y-1 ml-2">{children}</ul>
     </div>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -97,7 +97,7 @@ export default function Header({ barColor }: HeaderProps) {
             </a>
           </div>
         </div>
-        <div className="flex md:hidden items-center gap-2 mt-1">
+        <div className="flex md:hidden items-center gap-1 mt-1 whitespace-nowrap overflow-x-auto">
           <Link href="/experience" className="group text-sm transition-colors px-1 py-1">
             <span className={`transition-colors ${barColor === "yellow" ? "text-onedark-yellow" : "text-onedark-gutter group-hover:text-onedark-yellow"}`}>[</span>
             <span className="text-onedark-yellow"> experience </span>


### PR DESCRIPTION
- Prevent mobile nav links from wrapping to multiple lines by adding
  whitespace-nowrap and reducing gap spacing
- Change uses page section headers from yellow to purple to match
  the page's purple color theme

https://claude.ai/code/session_0115CbGknus7nSooTjwYLYh9